### PR TITLE
Passing the umbrella target to settings_post_process

### DIFF
--- a/lib/cocoapods_acknowledgements.rb
+++ b/lib/cocoapods_acknowledgements.rb
@@ -78,7 +78,7 @@ module CocoaPodsAcknowledgements
               
               # Support a callback for the key :settings_post_process
               if user_options["settings_post_process"]
-                user_options["settings_post_process"].call(settings_plist_path)
+                user_options["settings_post_process"].call(settings_plist_path, umbrella_target)
               end
               
             end


### PR DESCRIPTION
Fixes #8 

```ruby
plugin 'cocoapods-acknowledgements', :settings_bundle => true , :settings_post_process => Proc.new { |settings_plist_path, umbrella_target|
  puts "ACK"
  puts settings_plist_path
  puts target
  puts target.cocoapods_target_label
}
```

This breaks the previous `settings_post_process` interface, but as the plugin is not yet released IMO it's not an issue.