### PR TITLE
Using sandbox provided by the hook

### DIFF
--- a/lib/cocoapods_acknowledgements.rb
+++ b/lib/cocoapods_acknowledgements.rb
@@ -46,8 +46,10 @@ module CocoaPodsAcknowledgements
     Pod::UI.section 'Adding Acknowledgements' do
 
       should_include_settings = user_options["settings_bundle"] != nil
-      
-      sandbox = Pod::Sandbox.new(context.sandbox_root)
+
+      sandbox = context.sandbox if defined? context.sandbox
+      sandbox ||= Pod::Sandbox.new(context.sandbox_root)
+
       context.umbrella_targets.each do |umbrella_target|
         project = Xcodeproj::Project.open(umbrella_target.user_project_path)
         


### PR DESCRIPTION
This fixes #3.

It needs an unreleased version of CocoaPods to fix the issue (because of https://github.com/CocoaPods/CocoaPods/pull/4487), but I kept the previous behavior if a `sandbox` isn't provided by the context.