### PR TITLE
Fixing adding same file multiple times to group

### DIFF
--- a/lib/cocoapods_acknowledgements.rb
+++ b/lib/cocoapods_acknowledgements.rb
@@ -12,7 +12,8 @@ module CocoaPodsAcknowledgements
     end
 
     # Add the example plist to the found CocoaPods group
-    file_ref = cocoapods_group.files.find { |file| file.real_path == plist_path }
+    plist_pathname = Pathname.new(File.expand_path(plist_path))
+    file_ref = cocoapods_group.files.find { |file| file.real_path == plist_pathname }
     unless file_ref
       file_ref = cocoapods_group.new_file(plist_path)
     end


### PR DESCRIPTION
`file.real_path` is a `Pathname`, while `plist_path` is a `String` with a relative path (that's why the `File.expand_path` is needed.

Without this change, `file_ref` is always `nil`, so the files is added repeatedly to the `Pods` group (once each `pod install`).