### PR TITLE
Add the homepage to the metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ##### Enhancements
 
-* None.  
+* Add `homepage` to the spec's metadata.  
+  [Orta Therox](https://github.com/orta)
 
 ##### Bug Fixes
 

--- a/lib/cocoapods_acknowledgements/plist_generator.rb
+++ b/lib/cocoapods_acknowledgements/plist_generator.rb
@@ -29,6 +29,7 @@ module CocoaPodsAcknowledgements
             "description" => parse_markdown(spec.description),
             "licenseType" => spec.license[:type],
             "licenseText" => license_text,
+            "homepage" => spec.homepage,
           }
           specs_metadata << spec_metadata
         end


### PR DESCRIPTION
When I started wrapping up CPDAcknowledgements - I noticed that this was missing from the metadata