### PR TITLE
Search project files for the Settings.bundle file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ##### Enhancements
 
-* None.  
+* Update matching for `Settings.bundle` file in project.  
+  [Jim Hildensperger](https://github.com/jhildensperger)
 
 ##### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ plugin 'cocoapods-acknowledgements', :settings_bundle => true , :settings_post_p
 }
 ```
 
-The plugin will search through the first two levels of your project to find a `Settings.bundle` file, and add the file to the bundle. If this is not enough for you, we'd love a PR.
+The plugin will search through your project files to find a `Settings.bundle` file, and add the file to the bundle. If this is not enough for you, we'd love a PR.
 
 You can also exclude some dependencies so they won't be added to the generated plists. This is useful when you don't want to add private dependencies.
 

--- a/lib/cocoapods_acknowledgements.rb
+++ b/lib/cocoapods_acknowledgements.rb
@@ -32,9 +32,9 @@ module CocoaPodsAcknowledgements
 
   end
 
-  # TODO: Code golf this
-  def self.settings_bundle_in_project
-    Dir.glob("**/*Settings.bundle").first
+  def self.settings_bundle_in_project(project)
+    file = project.files.find { |f| f.path =~ /Settings\.bundle$/ }
+    file.hierarchy_path.sub('/', '') unless file.nil?
   end
 
   Pod::HooksManager.register('cocoapods-acknowledgements', :post_install) do |context, user_options|
@@ -77,7 +77,7 @@ module CocoaPodsAcknowledgements
             # We need to look for a Settings.bundle
             # and add this to the root of the bundle
 
-            settings_bundle = settings_bundle_in_project
+            settings_bundle = settings_bundle_in_project(project)
             if settings_bundle == nil
               Pod::UI.warn "Could not find a Settings.bundle to add the Pod Settings Plist to."
             else


### PR DESCRIPTION
I have my build directory in the same folder as my project and using `Dir.glob("**/*Settings.bundle").first` is matching the Settings.bundle file from a previous build.

This seems to fix the issue for my use case.