### PR TITLE
Refer to path on disk instead of hierarchy path in Xcode

### DIFF
--- a/lib/cocoapods_acknowledgements.rb
+++ b/lib/cocoapods_acknowledgements.rb
@@ -34,7 +34,7 @@ module CocoaPodsAcknowledgements
 
   def self.settings_bundle_in_project(project)
     file = project.files.find { |f| f.path =~ /Settings\.bundle$/ }
-    file.hierarchy_path.sub('/', '') unless file.nil?
+    file.real_path.to_path unless file.nil?
   end
 
   Pod::HooksManager.register('cocoapods-acknowledgements', :post_install) do |context, user_options|


### PR DESCRIPTION
Hiya,

The previous code was building the path by collapsing the hierarchy in Xcode's project view, which does not necessarily reflect the path/structure on disk.

This fix will return the actual path on disk to the `Settings.bundle` file.