### PR TITLE
Add an option to specify targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Add `targets` options to specify targets to add metadata  
+ [Richard Lee](https://github.com/dlackty)
+ [#46](https://github.com/CocoaPods/cocoapods-acknowledgements/issues/46)
+
 * Improve the performance of metadata generation  
  [Eric Amorde](https://github.com/amorde)
  [#54](https://github.com/CocoaPods/cocoapods-acknowledgements/pull/54)

--- a/README.md
+++ b/README.md
@@ -35,12 +35,18 @@ plugin 'cocoapods-acknowledgements', :settings_bundle => true , :settings_post_p
 
 The plugin will search through your project files to find a `Settings.bundle` file, and add the file to the bundle. If this is not enough for you, we'd love a PR.
 
-You can also exclude some dependencies so they won't be added to the generated plists. This is useful when you don't want to add private dependencies.
+You can exclude some dependencies so they won't be added to the generated plists. This is useful when you don't want to add private dependencies.
 
 ```ruby
 plugin 'cocoapods-acknowledgements', :settings_bundle => true, :exclude => 'PrivateKit'
 
 plugin 'cocoapods-acknowledgements', :settings_bundle => true, :exclude => ['PrivateKit', 'SecretLib']
+```
+
+You can also specify a list of targets for which to generate acknowledgements. This can be useful to exclude test or extension targets.
+
+``` ruby
+plugin 'cocoapods-acknowledgements', :targets => ['MyApp']
 ```
 
 ### Location

--- a/lib/cocoapods_acknowledgements.rb
+++ b/lib/cocoapods_acknowledgements.rb
@@ -29,7 +29,6 @@ module CocoaPodsAcknowledgements
     end
 
     project.save
-
   end
 
   def self.settings_bundle_in_project(project)
@@ -53,6 +52,7 @@ module CocoaPodsAcknowledgements
 
       should_include_settings = user_options["settings_bundle"]
       excluded_pods = Set.new(user_options["exclude"])
+      targets = Set.new(user_options["targets"])
 
       sandbox = context.sandbox if defined? context.sandbox
       sandbox ||= Pod::Sandbox.new(context.sandbox_root)
@@ -78,8 +78,16 @@ module CocoaPodsAcknowledgements
         end
 
         plist_path = sandbox.root + "#{umbrella_target.cocoapods_target_label}-metadata.plist"
-        
-        umbrella_target.user_target_uuids.each do |user_target_uuid|
+
+        user_target_uuids = if targets.empty?
+          umbrella_target.user_target_uuids
+        else
+          umbrella_target.user_targets.select do |target|
+            targets.include?(target.name)
+          end.map(&:uuid)
+        end
+
+        user_target_uuids.each do |user_target_uuid|
           save_metadata(metadata, plist_path, project, sandbox, user_target_uuid)
 
           if settings_metadata && settings_plist_path

--- a/spec/acknowledgement_spec.rb
+++ b/spec/acknowledgement_spec.rb
@@ -143,5 +143,13 @@ describe CocoaPodsAcknowledgements do
       Pod::HooksManager.run(:post_install, @hook_context, { 'cocoapods-acknowledgements' => { :settings_bundle => true }})
       FileUtils.rm_rf(settings_bundle)
     end
+
+    it "generates acknowledgement plists to only specified targets" do
+      CocoaPodsAcknowledgements.expects(:save_metadata).with(@plist_content, @plist_path, @project, @sandbox, @target.uuid).once
+      Pod::HooksManager.run(:post_install, @hook_context, { 'cocoapods-acknowledgements' => { targets: ['MyApp'] }})
+
+      CocoaPodsAcknowledgements.expects(:save_metadata).never
+      Pod::HooksManager.run(:post_install, @hook_context, { 'cocoapods-acknowledgements' => { targets: ['TheOtherTarget'] }})
+    end
   end
 end


### PR DESCRIPTION
As titled, I added an option to specify which targets to save metadata plist.

This should resolve #46.