### PR TITLE
Update redcarpet to 3.5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,13 +3,13 @@ PATH
   specs:
     cocoapods-acknowledgements (1.3.0)
       cocoapods
-      redcarpet (~> 3.3)
+      redcarpet (~> 3.5.1)
       xcodeproj
 
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.2)
+    CFPropertyList (3.0.3)
     activesupport (5.2.4.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -17,16 +17,16 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    algoliasearch (1.27.4)
+    algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
     bacon (1.2.0)
     claide (1.0.3)
-    cocoapods (1.10.0)
+    cocoapods (1.10.1)
       addressable (~> 2.6)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.10.0)
+      cocoapods-core (= 1.10.1)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.4.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -41,7 +41,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (~> 1.4)
       xcodeproj (>= 1.19.0, < 2.0)
-    cocoapods-core (1.10.0)
+    cocoapods-core (1.10.1)
       activesupport (> 5.0, < 6)
       addressable (~> 2.6)
       algoliasearch (~> 1.0)
@@ -65,16 +65,16 @@ GEM
     escape (0.0.4)
     ethon (0.12.0)
       ffi (>= 1.3.0)
-    ffi (1.13.1)
+    ffi (1.14.2)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.8.5)
+    i18n (1.8.7)
       concurrent-ruby (~> 1.0)
-    json (2.3.1)
+    json (2.5.1)
     metaclass (0.0.4)
-    minitest (5.14.2)
+    minitest (5.14.3)
     mocha (0.11.4)
       metaclass (~> 0.0.1)
     mocha-on-bacon (0.2.1)
@@ -87,12 +87,12 @@ GEM
       bacon (~> 1.2)
     public_suffix (4.0.6)
     rake (13.0.1)
-    redcarpet (3.5.0)
+    redcarpet (3.5.1)
     ruby-macho (1.4.0)
     thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.7)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     xcodeproj (1.19.0)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -103,6 +103,7 @@ GEM
 
 PLATFORMS
   ruby
+  universal-darwin-20
 
 DEPENDENCIES
   bacon
@@ -114,4 +115,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.1.2
+   2.2.0

--- a/cocoapods_acknowledgements.gemspec
+++ b/cocoapods_acknowledgements.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'cocoapods'
 
-  spec.add_dependency "redcarpet", "~> 3.3"
+  spec.add_dependency "redcarpet", "~> 3.5.1"
   spec.add_dependency "xcodeproj"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Updated [redcarpet](https://github.com/vmg/redcarpet) to 3.5.1 due to [security vulnerability ](https://github.com/vmg/redcarpet/issues/700).